### PR TITLE
Regenerate new proto stubs

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,4 +1,5 @@
-version: v1beta1
+version: v1
 plugins:
-  - name: python
+  - remote: buf.build/protocolbuffers/plugins/python:v21.9.0-1
     out: ../gen/
+


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

This PR bumps `grpc-gateway` to https://github.com/grpc-ecosystem/grpc-gateway/commit/b1dfa9873a386a695920cee2a291b12e7b5a5a96 and changes the buf config files to use a remote plugin.

This is necessary because of the breaking change announced in https://developers.google.com/protocol-buffers/docs/news/2022-05-06, otherwise, whoever installs this package will see this error coming from the `protobuf` library:
```
...
    from protoc_gen_openapiv2.options import annotations_pb2 as protoc__gen__openapiv2_dot_options_dot_annotations__pb2
  File "/tmp/tmp.qJ9AAP8b6s/venv/lib/python3.10/site-packages/protoc_gen_openapiv2/options/annotations_pb2.py", line 15, in <module>
    from protoc_gen_openapiv2.options import openapiv2_pb2 as protoc__gen__openapiv2_dot_options_dot_openapiv2__pb2
  File "/tmp/tmp.qJ9AAP8b6s/venv/lib/python3.10/site-packages/protoc_gen_openapiv2/options/openapiv2_pb2.py", line 35, in <module>
    _descriptor.EnumValueDescriptor(
  File "/tmp/tmp.qJ9AAP8b6s/venv/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```